### PR TITLE
chore: Remove unnecessary Number conversion for dstChain

### DIFF
--- a/services/ts-filler/scripts/generateProof.ts
+++ b/services/ts-filler/scripts/generateProof.ts
@@ -20,7 +20,7 @@ async function main() {
     throw new Error(`Invalid L1 Chain: ${config.l1}`);
   }
   if (!activeChains.dst) {
-    throw new Error(`Invalid Destination Chain: ${Number(config.dstChain)}`);
+    throw new Error(`Invalid Destination Chain: ${config.dstChain}`);
   }
 
   const configService = new ConfigService();


### PR DESCRIPTION
Noticed that `config.dstChain` was being wrapped with `Number()`, but this conversion isn't needed. If `dstChain` is already a string (e.g., a network identifier), there's no reason to cast it.

The check now correctly logs the value as it is, making the code more consistent with how `src` and `l1` chains are handled.