### PR TITLE
fix: explicitly initialize loop variable `i`

### DIFF
--- a/contracts/script/RecoverPaymasterFunds.s.sol
+++ b/contracts/script/RecoverPaymasterFunds.s.sol
@@ -14,7 +14,7 @@ contract RecoverPaymasterFunds is MultiChain {
     function run() public {
         HelperConfig helperConfig = new HelperConfig();
 
-        for (uint256 i; i < chains.length; i++) {
+        for (uint256 i = 0; i < chains.length; i++) {
             vm.createSelectFork(chains[i].rpcUrl);
 
             HelperConfig.NetworkConfig memory cfg = helperConfig.getConfig(block.chainid);


### PR DESCRIPTION
I fixed an issue where the loop variable `i` was not explicitly initialized in the `for` loop. In Solidity, an uninitialized variable defaults to `0`, which can lead to unexpected behavior and confusion for developers. Explicitly initializing `i` to `0` ensures better readability and avoids potential misunderstandings in the future.