### PR TITLE
Fix Storage Indexing Issue in HashiBase.s.sol

### DIFF
--- a/contracts/script/submitRequest/HashiBase.s.sol
+++ b/contracts/script/submitRequest/HashiBase.s.sol
@@ -19,13 +19,13 @@ contract HashiBase is StandardBase {
 
         bytes[] memory newAttributes = new bytes[](attributes.length + 1);
 
-        for (uint256 i; i < attributes.length - 1; i++) {
+        for (uint256 i = 0; i < attributes.length - 1; i++) {
             newAttributes[i] = attributes[i];
         }
 
         newAttributes[attributes.length - 1] =
             abi.encodeWithSelector(_SHOYU_BASHI_ATTRIBUTE_SELECTOR, srcConfig.shoyuBashi);
-        newAttributes[attributes.length] = abi.encodeWithSelector(_DESTINATION_CHAIN_SELECTOR, destinationChain);
+        newAttributes[attributes.length - 1] = abi.encodeWithSelector(_DESTINATION_CHAIN_SELECTOR, destinationChain);
 
         return (destinationChain, receiver, payload, newAttributes);
     }


### PR DESCRIPTION
Loop Initialization Issue:
In Solidity, a loop variable must be explicitly initialized. The previous code omitted i = 0, which could cause compilation warnings or errors.
Array Out-of-Bounds Issue:
The previous implementation attempted to access newAttributes[attributes.length], which is out of bounds in a length + 1 array. Using attributes.length - 1 correctly assigns the last slot.